### PR TITLE
Minor changes for easier use

### DIFF
--- a/example.c
+++ b/example.c
@@ -3,9 +3,10 @@
 
 int main() {
 	i2c bus = i2cOpen("/dev/i2c-1");
-	PCA9685_init(bus);
 
 	PCA9685_setFreq(bus, 1000);
+	PCA9685_init(bus);
+
 	PCA9685_setDutyCicle(bus, 15, 99);
 
 	printf("Press enter to quit.");

--- a/pca9685.c
+++ b/pca9685.c
@@ -5,8 +5,10 @@ int PCA9685_init(i2c bus) {
 		+ i2cRegWrite(bus, PCA9685_ADDRESS, PCA9685_MODE2, PCA9685_OUTDRV);
 }
 
-int PCA9685_setDutyCicle(i2c bus, char channel, unsigned short value) {
-	value = (PCA9685_MAX_DUTY_CICLE * value) / 100;
+int PCA9685_setDutyCicle(i2c bus, char channel, short value) {
+	value = value < 0? 0:
+			value > 100? PCA9685_MAX_DUTY_CICLE:
+			(PCA9685_MAX_DUTY_CICLE * value) / 100;
 
 	unsigned char buf[5];
 	buf[0] = PCA9685_LED0_ON_L + (PCA9685_REGISTERS_PER_CHANNEL * channel);
@@ -17,7 +19,10 @@ int PCA9685_setDutyCicle(i2c bus, char channel, unsigned short value) {
 }
 
 int PCA9685_setFreq(i2c bus, unsigned short freq) {
-	freq = 25000000 / (4096 * freq);
+	freq = freq < 24? 0xFF:
+			freq > 1526? 0x03:
+			25000000 / (4096 * freq);
+
 	return i2cRegWrite(bus, PCA9685_ADDRESS, PCA9685_PRE_SCALE, freq);
 }
 

--- a/pca9685.c
+++ b/pca9685.c
@@ -1,25 +1,26 @@
 #include "pca9685.h"
 
 int PCA9685_init(i2c bus) {
-	return i2cRegWrite(bus, ADDRESS, MODE1, ALLCALL | AI) + i2cRegWrite(bus, ADDRESS, MODE2, OUTDRV);
+	return i2cRegWrite(bus, PCA9685_ADDRESS, PCA9685_MODE1, PCA9685_ALLCALL | PCA9685_AI)
+		+ i2cRegWrite(bus, PCA9685_ADDRESS, PCA9685_MODE2, PCA9685_OUTDRV);
 }
 
 int PCA9685_setDutyCicle(i2c bus, char channel, unsigned short value) {
-	value = (MAX_DUTY_CICLE * value) / 100;
+	value = (PCA9685_MAX_DUTY_CICLE * value) / 100;
 
 	unsigned char buf[5];
-	buf[0] = LED0_ON_L + (REGISTERS_PER_CHANNEL * channel);
+	buf[0] = PCA9685_LED0_ON_L + (PCA9685_REGISTERS_PER_CHANNEL * channel);
 	buf[1] = buf[2] = 0x00;
 	buf[3] = value & 0xFF; buf[4] = (value >> 8) & 0xF;
 
-	return i2cWrite(bus, ADDRESS, buf, 5);
+	return i2cWrite(bus, PCA9685_ADDRESS, buf, 5);
 }
 
 int PCA9685_setFreq(i2c bus, unsigned short freq) {
 	freq = 25000000 / (4096 * freq);
-	return i2cRegWrite(bus, ADDRESS, PRE_SCALE, freq);
+	return i2cRegWrite(bus, PCA9685_ADDRESS, PCA9685_PRE_SCALE, freq);
 }
 
 int PCA9685_stop(i2c bus) {
-	return i2cRegWrite(bus, ADDRESS, MODE1, SLEEP);
+	return i2cRegWrite(bus, PCA9685_ADDRESS, PCA9685_MODE1, PCA9685_SLEEP);
 }

--- a/pca9685.h
+++ b/pca9685.h
@@ -1,15 +1,15 @@
 #include "i2c.h"
-#define MODE1 0x00
-#define MODE2 0x01
-#define LED0_ON_L 0x06
-#define ADDRESS 0x40
-#define ALLCALL 0x01
-#define SLEEP 0x10
-#define AI 0x20
-#define OUTDRV 0x04
-#define PRE_SCALE 0xFE
-#define MAX_DUTY_CICLE 4095
-#define REGISTERS_PER_CHANNEL 4
+#define PCA9685_MODE1 0x00
+#define PCA9685_MODE2 0x01
+#define PCA9685_LED0_ON_L 0x06
+#define PCA9685_ADDRESS 0x40
+#define PCA9685_ALLCALL 0x01
+#define PCA9685_SLEEP 0x10
+#define PCA9685_AI 0x20
+#define PCA9685_OUTDRV 0x04
+#define PCA9685_PRE_SCALE 0xFE
+#define PCA9685_MAX_DUTY_CICLE 4095
+#define PCA9685_REGISTERS_PER_CHANNEL 4
 int PCA9685_init(i2c bus);
 int PCA9685_setDutyCicle(i2c bus, char channel, unsigned short value);
 int PCA9685_setFreq(i2c bus, unsigned short freq);

--- a/pca9685.h
+++ b/pca9685.h
@@ -11,6 +11,6 @@
 #define PCA9685_MAX_DUTY_CICLE 4095
 #define PCA9685_REGISTERS_PER_CHANNEL 4
 int PCA9685_init(i2c bus);
-int PCA9685_setDutyCicle(i2c bus, char channel, unsigned short value);
+int PCA9685_setDutyCicle(i2c bus, char channel, short value);
 int PCA9685_setFreq(i2c bus, unsigned short freq);
 int PCA9685_stop(i2c bus);


### PR DESCRIPTION
According with the datasheet, section 7.3.5 (page 25), "The PRE_SCALE register can only be set when the SLEEP bit of MODE1 register is set to logic 1", so, PCA9685_setFreq() should be used before PCA9685_init().
Constants have now a prefix to avoid any name collision with others constants that the main code may want to use.
Duty cycle function PCA9685_setDutyCicle() now saturate on 0 and 100% to make easier to use with a controller output.
Frequency function PCA9685_setFreq() also saturates on max and min frequencies.